### PR TITLE
Zoom Value is Capped Too Low

### DIFF
--- a/examples/visca_cli.c
+++ b/examples/visca_cli.c
@@ -1135,7 +1135,7 @@ int doCommand(char *commandline, int *ret1, int *ret2, int *ret3) {
   }
 
   if (strcmp(command, "set_zoom_value") == 0) {
-    if ((arg1 == NULL) || (intarg1 < 0) || (intarg1 > 1023)) {
+    if ((arg1 == NULL) || (intarg1 < 0) || (intarg1 > 15000)) {
       return 41;
     }
     if (VISCA_set_zoom_value(&iface, &camera, intarg1)!=VISCA_SUCCESS) {


### PR DESCRIPTION
visca_cli only accepts up to a 1024 zoom value, but my D70p will accept values in excess of 15000 - 1024 is barely zoomed in at all.
